### PR TITLE
Fixes to get true max and mins, added center to Ibox for getbounds

### DIFF
--- a/src/interfaces/Ibox.ts
+++ b/src/interfaces/Ibox.ts
@@ -1,7 +1,10 @@
-﻿export interface IBox {
+﻿import { ILatLong } from './ilatlong';
+
+export interface IBox {
     maxLatitude: number;
     maxLongitude: number;
     minLatitude: number;
     minLongitude: number;
+    center?: ILatLong;
     padding?: number;
 }

--- a/src/services/bingMaps/bing-map.service.ts
+++ b/src/services/bingMaps/bing-map.service.ts
@@ -321,11 +321,11 @@ export class BingMapService implements MapService {
             return <IBox>{
                 maxLatitude: box.center.latitude + halfWidth > 180 ?
                     box.center.latitude - halfWidth : box.center.latitude + halfWidth,
-                maxLongitude: box.center.longitude + halfHeight > 180 ?
+                maxLongitude: box.center.longitude + halfHeight > 90 ?
                     box.center.longitude - halfHeight : box.center.longitude + halfHeight,
                 minLatitude: box.center.latitude - halfWidth < -180 ?
                     box.center.latitude + halfWidth : box.center.latitude - halfWidth,
-                minLongitude: box.center.longitude - halfHeight < -180 ?
+                minLongitude: box.center.longitude - halfHeight < -90 ?
                     box.center.longitude + halfHeight : box.center.longitude - halfHeight,
                 center: { latitude: box.center.latitude, longitude: box.center.longitude },
                 padding: 0

--- a/src/services/bingMaps/bing-map.service.ts
+++ b/src/services/bingMaps/bing-map.service.ts
@@ -319,10 +319,15 @@ export class BingMapService implements MapService {
             const halfWidth = (box.width / 2);
             const halfHeight = (box.height / 2);
             return <IBox>{
-                maxLatitude: box.center.latitude + halfWidth,
-                maxLongitude: box.center.longitude + halfHeight,
-                minLatitude: box.center.latitude - halfWidth,
-                minLongitude: box.center.longitude - halfHeight,
+                maxLatitude: box.center.latitude + halfWidth > 180 ?
+                    box.center.latitude - halfWidth : box.center.latitude + halfWidth,
+                maxLongitude: box.center.longitude + halfHeight > 180 ?
+                    box.center.longitude - halfHeight : box.center.longitude + halfHeight,
+                minLatitude: box.center.latitude - halfWidth < -180 ?
+                    box.center.latitude + halfWidth : box.center.latitude - halfWidth,
+                minLongitude: box.center.longitude - halfHeight < -180 ?
+                    box.center.longitude + halfHeight : box.center.longitude - halfHeight,
+                center: { latitude: box.center.latitude, longitude: box.center.longitude },
                 padding: 0
             };
         });

--- a/src/services/google/google-map.service.ts
+++ b/src/services/google/google-map.service.ts
@@ -280,10 +280,11 @@ export class GoogleMapService implements MapService {
         return this._map.then((map: GoogleMapTypes.GoogleMap) => {
             const box = map.getBounds();
             return <IBox>{
-                maxLatitude: box.getNorthEast().lat(),
-                maxLongitude: box.getNorthEast().lng(),
-                minLatitude: box.getSouthWest().lat(),
-                minLongitude: box.getSouthWest().lng(),
+                maxLatitude: Math.max(box.getNorthEast().lat(), box.getSouthWest().lat()),
+                maxLongitude: Math.max(box.getNorthEast().lng(), box.getSouthWest().lng()),
+                minLatitude: Math.min(box.getNorthEast().lat(), box.getSouthWest().lat()),
+                minLongitude: Math.min(box.getNorthEast().lng(), box.getSouthWest().lng()),
+                center: { latitude: box.getCenter().lat(), longitude: box.getCenter().lng() },
                 padding: 0
             };
         });


### PR DESCRIPTION
Fixes to bounding box queries to make max and min really max and min
     - previously when you crossed the international dateline 180 switches to -180 and the max and min would not account for that.

Adding center to get rid of ambiguity in which spherical arc to take (e.g. front-side of the earth or the back-side of the earth which are both defined by the same two points)
     - this will help in calculating queries off of the bounding box, you will be able to make an intelligent calculation based off of which side of the world you will want to look at.