### PR TITLE
Add ability to hide labels in Bing and show in Google via MapTypeId.Hybrid

### DIFF
--- a/src/components/map.ts
+++ b/src/components/map.ts
@@ -451,7 +451,7 @@ export class MapComponent implements OnChanges, OnInit, OnDestroy {
     private InitMapInstance(el: HTMLElement) {
         if (this._options.center == null) { this._options.center = { latitude: this._latitude, longitude: this._longitude }; }
         if (this._options.zoom == null) { this._options.zoom = this._zoom; }
-        if (this._options.mapTypeId == null) { this._options.mapTypeId = MapTypeId.aerial; }
+        if (this._options.mapTypeId == null) { this._options.mapTypeId = MapTypeId.hybrid; }
         if (this._box != null) { this._options.bounds = this._box; }
         this._mapPromise = this._mapService.CreateMap(el, this._options);
         this.HandleMapCenterChange();

--- a/src/models/map-type-id.ts
+++ b/src/models/map-type-id.ts
@@ -12,6 +12,9 @@
     /** A grayscale version of the road maps. */
     grayscale,
 
+    /** The aerial map type including lables */
+    hybrid,
+
     /** Displays a blank canvas that uses the mercator map project. It basically removed the base maps layer. */
     mercator,
 

--- a/src/services/bing/bing-conversions.ts
+++ b/src/services/bing/bing-conversions.ts
@@ -318,7 +318,17 @@ export class BingConversions {
                 if (k === 'center') {
                     o.center = BingConversions.TranslateLocation(options.center);
                 } else if (k === 'mapTypeId') {
-                    o.mapTypeId = Microsoft.Maps.MapTypeId[(<any>MapTypeId)[options.mapTypeId]];
+                    if(options.mapTypeId === MapTypeId.hybrid) {
+                        o.mapTypeId = Microsoft.Maps.MapTypeId.aerial;
+                        o.labelOverlay = Microsoft.Maps.LabelOverlay.visible;
+                    }
+                    else if (options.mapTypeId === MapTypeId.aerial) {
+                        o.mapTypeId = Microsoft.Maps.MapTypeId.aerial;
+                        o.labelOverlay = Microsoft.Maps.LabelOverlay.hidden;
+                    }
+                    else {
+                        o.mapTypeId = Microsoft.Maps.MapTypeId[(<any>MapTypeId)[options.mapTypeId]];
+                    }
                 } else if (k === 'bounds') {
                     o.bounds = BingConversions.TranslateBounds(options.bounds);
                 } else {

--- a/src/services/google/google-conversions.ts
+++ b/src/services/google/google-conversions.ts
@@ -313,6 +313,8 @@ export class GoogleConversions {
         switch (mapTypeId) {
             case MapTypeId.road: return GoogleMapTypes.MapTypeId[GoogleMapTypes.MapTypeId.roadmap];
             case MapTypeId.grayscale: return GoogleMapTypes.MapTypeId[GoogleMapTypes.MapTypeId.terrain];
+            case MapTypeId.hybrid: return GoogleMapTypes.MapTypeId[GoogleMapTypes.MapTypeId.hybrid];
+            case MapTypeId.ordnanceSurvey: return GoogleMapTypes.MapTypeId[GoogleMapTypes.MapTypeId.terrain];
             default: return GoogleMapTypes.MapTypeId[GoogleMapTypes.MapTypeId.satellite];
         }
     }

--- a/src/services/google/google-map.service.ts
+++ b/src/services/google/google-map.service.ts
@@ -17,6 +17,7 @@ import { IMarkerIconInfo } from '../../interfaces/imarker-icon-info';
 import { IPolygonOptions } from '../../interfaces/ipolygon-options';
 import { IPolylineOptions } from '../../interfaces/ipolyline-options';
 import { IInfoWindowOptions } from '../../interfaces/iinfo-window-options';
+import { MapTypeId } from '../../models/map-type-id';
 import { Marker } from '../../models/marker';
 import { Polygon } from '../../models/polygon';
 import { Polyline } from '../../models/polyline';
@@ -158,6 +159,8 @@ export class GoogleMapService implements MapService {
     public CreateMap(el: HTMLElement, mapOptions: IMapOptions): Promise<void> {
         return this._loader.Load().then(() => {
             ExtendMapLabelWithOverlayView();
+            if (!mapOptions.mapTypeId) { mapOptions.mapTypeId = MapTypeId.hybrid; }
+            
             const o: GoogleMapTypes.MapOptions = GoogleConversions.TranslateOptions(mapOptions);
             const map: GoogleMapTypes.GoogleMap = new google.maps.Map(el, o);
             if (mapOptions.bounds) {

--- a/src/services/google/google-map.service.ts
+++ b/src/services/google/google-map.service.ts
@@ -159,8 +159,8 @@ export class GoogleMapService implements MapService {
     public CreateMap(el: HTMLElement, mapOptions: IMapOptions): Promise<void> {
         return this._loader.Load().then(() => {
             ExtendMapLabelWithOverlayView();
-            if (!mapOptions.mapTypeId) { mapOptions.mapTypeId = MapTypeId.hybrid; }
-            
+            if (!mapOptions.mapTypeId == null) { mapOptions.mapTypeId = MapTypeId.hybrid; }
+
             const o: GoogleMapTypes.MapOptions = GoogleConversions.TranslateOptions(mapOptions);
             const map: GoogleMapTypes.GoogleMap = new google.maps.Map(el, o);
             if (mapOptions.bounds) {


### PR DESCRIPTION
Add ability to hide labels in Bing and show in Google via MapTypeId.Hybrid. This is for a consistent experience between map implementations.