### PR TITLE
Nonblocking async layer

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "bingmaps": "^1.0.15",
     "font-awesome": "^4.6.3",
     "json-loader": "^0.5.4",
-    "lodash": "^4.17.4",
     "rxjs": "^5.2.0",
     "zone.js": "^0.8.2"
   },
@@ -48,7 +47,6 @@
     "@angular/platform-browser": ">=2.4.9",
     "@angular/platform-server": ">=2.4.9",
     "@types/async": "^2.0.45",
-    "@types/lodash": "^4.14.85",
     "@types/node": "^7.0.5",
     "codelyzer": ">=3.0.1",
     "tslint": ">=5.4.2",

--- a/package.json
+++ b/package.json
@@ -34,20 +34,24 @@
     "@angular/common": ">=2.4.9",
     "@angular/compiler": ">=2.4.9",
     "@angular/core": ">=2.4.9",
+    "async": "^2.5.0",
     "bingmaps": "^1.0.15",
     "font-awesome": "^4.6.3",
     "json-loader": "^0.5.4",
+    "lodash": "^4.17.4",
     "rxjs": "^5.2.0",
     "zone.js": "^0.8.2"
   },
   "devDependencies": {
     "@angular/animations": ">=2.4.9",
+    "@angular/compiler-cli": ">=2.4.9",
     "@angular/platform-browser": ">=2.4.9",
     "@angular/platform-server": ">=2.4.9",
-    "@angular/compiler-cli": ">=2.4.9",
+    "@types/async": "^2.0.45",
+    "@types/lodash": "^4.14.85",
+    "@types/node": "^7.0.5",
     "codelyzer": ">=3.0.1",
     "tslint": ">=5.4.2",
-    "@types/node": "^7.0.5",
     "typescript": "^2.3.2"
   }
 }

--- a/src/models/google/google-layer.ts
+++ b/src/models/google/google-layer.ts
@@ -1,5 +1,4 @@
-import { nextTick, whilst } from 'async';
-import { noop } from 'lodash';
+import { each, nextTick } from 'async';
 import { GoogleMarker } from './google-marker';
 import { ILayerOptions } from '../../interfaces/ilayer-options';
 import { MapService } from '../../services/map.service';
@@ -101,15 +100,10 @@ export class GoogleLayer implements Layer {
     public AddEntities(entities: Array<Marker|InfoWindow|Polygon|Polyline>): void {
         if (entities != null && Array.isArray(entities) && entities.length !== 0 ) {
             this._entities.push(...entities);
-            const entitiesToSet = [...entities];
-            whilst(
-                () => entitiesToSet.length > 0,
-                (next) => {
-                    entitiesToSet.splice(0, 50).forEach(e => e.NativePrimitve.setMap(this.NativePrimitve));
-                    nextTick(() => next());
-                },
-                (err) => noop()
-            );
+            each([...entities], (e, next) => {
+                e.NativePrimitve.setMap(this.NativePrimitve);
+                nextTick(() => next());
+            });
         }
     };
 
@@ -119,15 +113,10 @@ export class GoogleLayer implements Layer {
      * @memberof GoogleLayer
      */
     public Delete(): void {
-        const entitiesToSet = this._entities.splice(0);
-        whilst(
-            () => entitiesToSet.length > 0,
-            (next) => {
-                entitiesToSet.splice(0, 50).forEach(e => e.NativePrimitve.setMap(null));
-                nextTick(() => next());
-            },
-            (err) => noop()
-        );
+        each(this._entities.splice(0), (e, next) => {
+            e.NativePrimitve.setMap(null);
+            nextTick(() => next());
+        });
     }
 
     /**
@@ -203,15 +192,10 @@ export class GoogleLayer implements Layer {
      * @memberof GoogleMarkerClusterer
      */
     public SetVisible(visible: boolean): void {
-        const entitiesToSet = [...this._entities];
-        whilst(
-            () => entitiesToSet.length > 0,
-            (next) => {
-                entitiesToSet.splice(0, 50).forEach(e => e.NativePrimitve.setVisible(visible));
-                nextTick(() => next());
-            },
-            (err) => noop()
-        );
+        each([...this._entities], (e, next) => {
+            e.NativePrimitve.setVisible(visible);
+            nextTick(() => next());
+        });
         this._visible = visible;
     }
 

--- a/src/models/google/google-layer.ts
+++ b/src/models/google/google-layer.ts
@@ -1,3 +1,5 @@
+import { nextTick, whilst } from 'async';
+import { noop } from 'lodash';
 import { GoogleMarker } from './google-marker';
 import { ILayerOptions } from '../../interfaces/ilayer-options';
 import { MapService } from '../../services/map.service';
@@ -99,7 +101,15 @@ export class GoogleLayer implements Layer {
     public AddEntities(entities: Array<Marker|InfoWindow|Polygon|Polyline>): void {
         if (entities != null && Array.isArray(entities) && entities.length !== 0 ) {
             this._entities.push(...entities);
-            entities.forEach(e => e.NativePrimitve.setMap(this.NativePrimitve));
+            const entitiesToSet = [...entities];
+            whilst(
+                () => entitiesToSet.length > 0,
+                (next) => {
+                    entitiesToSet.splice(0, 50).forEach(e => e.NativePrimitve.setMap(this.NativePrimitve));
+                    nextTick(() => next());
+                },
+                (err) => noop()
+            );
         }
     };
 
@@ -109,10 +119,15 @@ export class GoogleLayer implements Layer {
      * @memberof GoogleLayer
      */
     public Delete(): void {
-        this._entities.forEach(m => {
-            m.NativePrimitve.setMap(null);
-        });
-        this._entities.splice(0);
+        const entitiesToSet = this._entities.splice(0);
+        whilst(
+            () => entitiesToSet.length > 0,
+            (next) => {
+                entitiesToSet.splice(0, 50).forEach(e => e.NativePrimitve.setMap(null));
+                nextTick(() => next());
+            },
+            (err) => noop()
+        );
     }
 
     /**
@@ -164,9 +179,8 @@ export class GoogleLayer implements Layer {
      * @memberof GoogleLayer
      */
     public SetEntities(entities: Array<Marker> | Array<InfoWindow> | Array<Polygon> | Array<Polyline>): void {
-        this._entities.splice(0).forEach(m => {m.NativePrimitve.setMap(null)});
-        this._entities.push(...entities);
-        this._entities.forEach(e => e.NativePrimitve.setMap(this.NativePrimitve));
+        this.Delete();
+        this.AddEntities(entities);
     }
 
     /**
@@ -189,10 +203,15 @@ export class GoogleLayer implements Layer {
      * @memberof GoogleMarkerClusterer
      */
     public SetVisible(visible: boolean): void {
-        const map: GoogleMapTypes.GoogleMap = visible ? this.NativePrimitve : null;
-        this._entities.forEach(m => {
-            m.NativePrimitve.setVisible(visible);
-        });
+        const entitiesToSet = [...this._entities];
+        whilst(
+            () => entitiesToSet.length > 0,
+            (next) => {
+                entitiesToSet.splice(0, 50).forEach(e => e.NativePrimitve.setVisible(visible));
+                nextTick(() => next());
+            },
+            (err) => noop()
+        );
         this._visible = visible;
     }
 

--- a/src/models/google/google-layer.ts
+++ b/src/models/google/google-layer.ts
@@ -1,4 +1,4 @@
-import { each, nextTick } from 'async';
+import { eachSeries, nextTick } from 'async';
 import { GoogleMarker } from './google-marker';
 import { ILayerOptions } from '../../interfaces/ilayer-options';
 import { MapService } from '../../services/map.service';
@@ -100,7 +100,7 @@ export class GoogleLayer implements Layer {
     public AddEntities(entities: Array<Marker|InfoWindow|Polygon|Polyline>): void {
         if (entities != null && Array.isArray(entities) && entities.length !== 0 ) {
             this._entities.push(...entities);
-            each([...entities], (e, next) => {
+            eachSeries([...entities], (e, next) => {
                 e.NativePrimitve.setMap(this.NativePrimitve);
                 nextTick(() => next());
             });
@@ -113,7 +113,7 @@ export class GoogleLayer implements Layer {
      * @memberof GoogleLayer
      */
     public Delete(): void {
-        each(this._entities.splice(0), (e, next) => {
+        eachSeries(this._entities.splice(0), (e, next) => {
             e.NativePrimitve.setMap(null);
             nextTick(() => next());
         });
@@ -192,7 +192,7 @@ export class GoogleLayer implements Layer {
      * @memberof GoogleMarkerClusterer
      */
     public SetVisible(visible: boolean): void {
-        each([...this._entities], (e, next) => {
+        eachSeries([...this._entities], (e, next) => {
             e.NativePrimitve.setVisible(visible);
             nextTick(() => next());
         });


### PR DESCRIPTION
- Including [caolan's async](https://github.com/caolan/async) library for the `eachSeries` and the `nextTick` methods.
- Using the spread operator (e.g. `[...entities]`) to iterate over a copy of the array, because we're now working asynchronously, we want to iterate over what we were originally given in case the array is modified during our process.
- The `SetEntities` method now avoids redundant, asynchronous code but could always be changed if the it needs to do anything beyond just removing and adding.