### PR TITLE
Added Bing lite mode map option

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,11 @@
 
 ```diff
 - #IMPORTANT
+- I don't plan to maintain this repository. I just added Bing liteMode option to address performance issues with vector labels
+```
+
+```diff
+- #IMPORTANT
 - On 10/6/2018, this repository will be migrated into the Avanade channel. While existing clones,
 - forks and branches will automatically redirect, we recommend that after the migration you repoint
 - your urls to the Avanade channel. 

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "codelyzer": ">=3.0.1",
     "ng-packagr": "^3.0.2",
     "tslint": ">=5.4.2",
-    "typescript": "~2.7.2",
+    "typescript": "^2.8.0",
     "zone.js": "^0.8.26"
   },
   "peerDependencies": {

--- a/src/interfaces/imap-options.ts
+++ b/src/interfaces/imap-options.ts
@@ -37,4 +37,5 @@ export interface IMapOptions {
     zoom?: number;
     mapTypeId?: MapTypeId;
     centerOffset?: IPoint;
+    liteMode?: boolean;
 }

--- a/src/services/bing/bing-conversions.ts
+++ b/src/services/bing/bing-conversions.ts
@@ -61,7 +61,8 @@ export class BingConversions {
         'width',
         'center',
         'zoom',
-        'mapTypeId'
+        'mapTypeId',
+        'liteMode'
     ];
 
     /**


### PR DESCRIPTION
There are performance issues with vector based labels at certain zoom levels. Bing maps provides lite mode [option](https://docs.microsoft.com/en-us/bingmaps/v8-web-control/map-control-api/mapoptions-object). 
If lite mode is true, vector labels are disabled