### PR TITLE
Fixed to let Map instance handle default center and zoom if not defined

### DIFF
--- a/src/components/map.ts
+++ b/src/components/map.ts
@@ -440,8 +440,8 @@ export class MapComponent implements OnChanges, OnInit, OnDestroy {
      */
     private InitMapInstance(el: HTMLElement) {
         this._zone.runOutsideAngular(() => {
-            if (this._options.center == null) { this._options.center = { latitude: this._latitude, longitude: this._longitude }; }
-            if (this._options.zoom == null) { this._options.zoom = this._zoom; }
+            if (this._options.center === null) { this._options.center = { latitude: this._latitude, longitude: this._longitude }; }
+            if (this._options.zoom === null) { this._options.zoom = this._zoom; }
             if (this._options.mapTypeId == null) { this._options.mapTypeId = MapTypeId.hybrid; }
             if (this._box != null) { this._options.bounds = this._box; }
             this._mapPromise = this._mapService.CreateMap(el, this._options);


### PR DESCRIPTION
A simple fix that lets `const map = new Microsoft.Maps.Map(el, o);` to set default center and zoom if those values are not provided in options.
In current implementation undefined is treated as null and private values of _latitude, _longitude and _zoom are set. Those values are 0.
