### PR TITLE
View child fix for Angular 9

### DIFF
--- a/src/components/map.ts
+++ b/src/components/map.ts
@@ -280,7 +280,12 @@ export class MapComponent implements OnChanges, OnInit, OnDestroy {
         this.MapService.emit(this._mapService);
     }
 
-    public ngAfterViewInit() {
+    /**
+     * Called after Angular has fully initialized a component's view. Part of ng Component life cycle.
+     *
+     * @memberof MapComponent
+     */
+    public ngAfterViewInit(): void {
         this.InitMapInstance(this._container.nativeElement);
     }
 

--- a/src/components/map.ts
+++ b/src/components/map.ts
@@ -92,7 +92,7 @@ export class MapComponent implements OnChanges, OnInit, OnDestroy {
     private _options: IMapOptions = {};
     private _box: IBox = null;
     private _mapPromise: Promise<void>;
-    @HostBinding('class.map-container') public _containerClass: boolean = true;
+    @HostBinding('class.map-container') public _containerClass = true;
     @ViewChild('container') private _container: ElementRef;
     @ContentChildren(MapMarkerDirective) private _markers: Array<MapMarkerDirective>;
 
@@ -276,9 +276,12 @@ export class MapComponent implements OnChanges, OnInit, OnDestroy {
      * @memberof MapComponent
      */
     public ngOnInit(): void {
-        this.InitMapInstance(this._container.nativeElement);
         this.MapPromise.emit(this._mapService.MapPromise);
         this.MapService.emit(this._mapService);
+    }
+
+    public ngAfterViewInit() {
+        this.InitMapInstance(this._container.nativeElement);
     }
 
     /**

--- a/src/components/map.ts
+++ b/src/components/map.ts
@@ -80,7 +80,7 @@ import { MapMarkerDirective } from './map-marker';
     encapsulation: ViewEncapsulation.None,
     changeDetection: ChangeDetectionStrategy.OnPush
 })
-export class MapComponent implements OnChanges, OnInit, OnDestroy {
+export class MapComponent implements OnChanges, OnInit, AfterViewInit, OnDestroy {
 
     ///
     /// Field declarations


### PR DESCRIPTION
`container` element ref is `undefined` in the `ngOnIt` lifecycle when calling `InitMapInstance` function.

This is a fix so any projects using this repo can be upgraded to Angular 9.

#127 